### PR TITLE
fix: use correct file structure

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bunzz",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "",
   "exports": {
     ".": "./dist/index.js"

--- a/src/commands/clone.ts
+++ b/src/commands/clone.ts
@@ -92,9 +92,10 @@ const cleanDirectories = (
     }
   } else {
     // Add '/contracts' to start of each path, ignoring ones that start with '@'
+    const alreadyHasContracts = distinctSegments.some((segment) => segment === 'contracts')
     for (let p of paths) {
-      if (!p.startsWith('@')) {
-        cleanedSources['contracts' + p] = sources[p];
+      if (!p.startsWith('@') && !alreadyHasContracts) {
+        cleanedSources[`contracts${!p.startsWith('/') ? '/' : ''}` + p] = sources[p];
       } else {
         cleanedSources[p] = sources[p];
       }
@@ -109,14 +110,7 @@ const mkDirFromSources = (
   projectPath: string
 ) => {
   for (const filePath in sources) {
-    // Convert the filePath to an absolute path
-    // if filePath doesn't start with '@' or /contracts, add /contracts to the beginning
-    const finalFilePath = !(
-      filePath.startsWith('@') || filePath.startsWith('contracts')
-    )
-      ? `contracts/${filePath}`
-      : filePath;
-    const absolutePath = path.join(projectPath, finalFilePath);
+    const absolutePath = path.join(projectPath, filePath);
 
     // Get the directory path
     const dirName = path.dirname(absolutePath);

--- a/src/tests/path.test.ts
+++ b/src/tests/path.test.ts
@@ -1,0 +1,73 @@
+import { fetchContractInfo, parseCode } from "../utils/gql";
+import {
+  cleanDirectories,
+  createHardhatConfig,
+  mkDirFromSources,
+} from "../utils/path";
+import * as path from "path";
+import fs from "fs/promises"; // Import the promise-based version
+
+describe("Cloning", () => {
+  let tempFolder: string;
+
+  beforeAll(() => {
+    tempFolder = path.join(__dirname, "temp");
+  });
+
+  afterAll(async () => {
+    await fs.rm(tempFolder, { recursive: true, force: true });
+  });
+
+  it("create proper project structure", async () => {
+    const contracts = [
+      {
+        chainId: "1",
+        contractAddress: "0xc36442b4a4522e871399cd717abdd847ab11fe88",
+      },
+      {
+        chainId: "1",
+        contractAddress: "0x000000000022d473030f116ddee9f6b43ac78ba3",
+      },
+    ];
+
+    await Promise.all(
+      contracts.map(async ({ chainId, contractAddress }) => {
+        const projectPath = path.join(tempFolder, contractAddress);
+        const {
+          code,
+          contractName,
+          optimizationUsed,
+          runs,
+          viaIR,
+          solidityVersion,
+        } = await fetchContractInfo({ env: "local" }, chainId, contractAddress);
+
+        const { sources } = parseCode(code, contractName);
+
+        mkDirFromSources(cleanDirectories(sources), projectPath);
+
+        createHardhatConfig(
+          projectPath,
+          solidityVersion,
+          {
+            enabled: optimizationUsed,
+            runs,
+            viaIR,
+          },
+          true
+        );
+
+        const { execSync } = require("child_process");
+
+        const compileOutput = execSync("hardhat compile", {
+          cwd: projectPath,
+          encoding: "utf8",
+        });
+
+        expect(compileOutput).toMatch(
+          /Compiled \d+ Solidity files successfully/
+        );
+      })
+    );
+  });
+});

--- a/src/utils/gql.ts
+++ b/src/utils/gql.ts
@@ -157,7 +157,6 @@ export const sendCloningAnalytics = async (options: any, chainId: string, contra
     return response.clonedContract.status;
   } catch (error: any) {
     console.log("Failed to send analytics to bunzz.dev")
-    console.error(error)
     handleGqlError(error);
     console.log("This error does not impact the cloning process and can be ignored")
   }


### PR DESCRIPTION
Users verify contracts in different ways and there are lots of unique file structures, it seems I did not manage to catch all the edge cases for recreating the file structure in such a way that hardhat can compile it.
This should fix some more cases